### PR TITLE
ci: add dependabot, update gha, test modern python versions, etc

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/simpervisor/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,25 +1,39 @@
-# Build releases and (on tags) publish to PyPI
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
 name: Release
 
-# always build releases (to make sure wheel-building works)
-# but only publish to PyPI on tags
 on:
-  push:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
   workflow_dispatch:
 
 jobs:
   build-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: install build package
         run: |
-          pip install --upgrade pip
           pip install build
           pip freeze
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,16 +1,31 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
----
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
 name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
   push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
   workflow_dispatch:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -21,10 +36,10 @@ jobs:
           - python-version: "3.9"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install
         run: |
@@ -33,9 +48,8 @@ jobs:
 
       - name: Test
         run: |
-          pytest --verbose --maxfail 3 --color=yes --log-cli-level DEBUG --cov=simpervisor tests/
+          pytest --verbose --maxfail=3 --color=yes --log-cli-level=DEBUG --cov=simpervisor tests/
 
       # GitHub action reference: https://github.com/codecov/codecov-action
-      - name: Upload code test coverage
-        uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,8 @@ jobs:
           - python-version: "3.7"
           - python-version: "3.8"
           - python-version: "3.9"
+          - python-version: "3.10"
+          - python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test
         run: |
-          pytest --verbose --maxfail=3 --color=yes --log-cli-level=DEBUG --cov=simpervisor tests/
+          pytest --maxfail=3 --log-cli-level=DEBUG --cov=simpervisor tests/
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 pytest
 pytest-asyncio
 pytest-cov
-codecov
 aiohttp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
 [tool.pytest.ini_options]
-markers = [
-  "asyncio"
-]
+addopts = "--verbose --color=yes --durations=10"
+asyncio_mode = "auto"

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -6,7 +6,6 @@ from simpervisor import SupervisedProcess
 import aiohttp
 import logging
 
-@pytest.mark.asyncio
 async def test_ready():
     """
     Test web app's readyness

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -9,7 +9,6 @@ import errno
 
 
 @pytest.mark.parametrize('childcount', [1, 5])
-@pytest.mark.asyncio
 async def test_sigtermreap(childcount):
     """
     Test reaping subprocess after SIGTERM.

--- a/tests/test_simpervisor.py
+++ b/tests/test_simpervisor.py
@@ -21,7 +21,6 @@ def sleep(retcode=0, time=SLEEP_TIME):
         '-c', 'import sys, time; time.sleep({}); sys.exit({})'.format(time, retcode)
     ]
 
-@pytest.mark.asyncio
 async def test_start_success():
     """
     Start a process & check its running status
@@ -34,7 +33,6 @@ async def test_start_success():
     await asyncio.sleep(SLEEP_WAIT_TIME)
     assert not proc.running
 
-@pytest.mark.asyncio
 async def test_start_always_restarting():
     """
     Start a process & check it restarts even when it succeeds
@@ -54,7 +52,6 @@ async def test_start_always_restarting():
     await proc.terminate()
     assert not proc.running
 
-@pytest.mark.asyncio
 async def test_start_fail_restarting():
     """
     Start a process that fails & make sure it restarts
@@ -75,7 +72,6 @@ async def test_start_fail_restarting():
     assert not proc.running
 
 
-@pytest.mark.asyncio
 async def test_start_multiple_start():
     """
     Starting the same process multiple times should be a noop
@@ -95,7 +91,6 @@ async def test_start_multiple_start():
 
 
 @pytest.mark.parametrize('method', ['start', 'kill', 'terminate'])
-@pytest.mark.asyncio
 async def test_method_after_kill(method):
     """
     Running 'method' on process after it has been killed should throw
@@ -112,7 +107,6 @@ async def test_method_after_kill(method):
         await getattr(proc, method)()
 
 
-@pytest.mark.asyncio
 async def test_kill():
     """
     Test killing processes
@@ -130,7 +124,6 @@ async def test_kill():
     assert e.value.errno == errno.ESRCH
 
 
-@pytest.mark.asyncio
 async def test_terminate():
     """
     Test terminating processes


### PR DESCRIPTION
@yuvipanda I searched for `codecov` in the jupyterhub org to help projects migrate from a deprecated python based CLI to a github action a binary they prefer that people use nowdays.

As part of that, I saw this repo and ended up making a few more fixes to keep it up to date with the jupyterhub org. Note that test has been broken since a while and is tracked in #12 already.