### PR TITLE
Convert `PORT` envvar to int to fix aiohttp/yarl compatibility

### DIFF
--- a/tests/child_scripts/simplehttpserver.py
+++ b/tests/child_scripts/simplehttpserver.py
@@ -11,7 +11,7 @@ wait_time = float(sys.argv[1])
 print("waiting", wait_time)
 time.sleep(wait_time)
 
-PORT = os.environ["PORT"]
+PORT = int(os.environ["PORT"])
 
 routes = web.RouteTableDef()
 


### PR DESCRIPTION
Conver the value of the `PORT` environment variable to int, to fix incompatibility with modern versions of aiohttp/yarl, that do expect the `port` argument to be one.

Fixes #49