### PR TITLE
fix: treat ProcessLookupError in _signal_and_wait as dead success

### DIFF
--- a/simpervisor/process.py
+++ b/simpervisor/process.py
@@ -273,13 +273,22 @@ class SupervisedProcess:
             # Don't yield control between sending signal & calling wait
             # This way, we don't end up in a call to _restart_process_if_needed
             # and possibly restarting. We also set _killed, just to be sure.
-            self.proc.send_signal(signum)
+            process_exists = True
+            try:
+                self.proc.send_signal(signum)
+            except ProcessLookupError:
+                # The child has already exited and asyncio's subprocess
+                # transport has reaped it, so the OS has no record of the
+                # pid. Treat this as an already-dead success.
+                process_exists = False
             self._killed = True
 
             # We cancel the restart watcher & wait for the process to finish,
-            # since we return only after the process has been reaped
+            # since we return only after the process has been reaped (when
+            # it still existed).
             self._restart_process_future.cancel()
-            await self.proc.wait()
+            if process_exists:
+                await self.proc.wait()
             self.running = False
             # Remove signal handler *after* the process is done
             remove_handler(self._handle_signal)

--- a/tests/test_simpervisor.py
+++ b/tests/test_simpervisor.py
@@ -145,3 +145,38 @@ async def test_terminate():
     assert proc.returncode == exitcode
     assert not proc.running
     assert not psutil.pid_exists(proc.pid)
+
+
+async def test_signal_and_wait_process_lookup_error():
+    """
+    If the underlying transport has already reaped the child, send_signal
+    raises ProcessLookupError. _signal_and_wait should treat that as
+    success: no exception, _killed and running updated, restart watcher
+    cancelled.
+    """
+    proc = SupervisedProcess(
+        inspect.currentframe().f_code.co_name, *sleep(0), always_restart=False
+    )
+    await proc.start()
+    assert proc.running
+
+    # Force the underlying Process.send_signal to raise ProcessLookupError,
+    # simulating the case where asyncio's subprocess transport has already
+    # noticed the child is gone.
+    def _raise_process_lookup(_signum):
+        raise ProcessLookupError(3, "No such process")
+
+    proc.proc.send_signal = _raise_process_lookup
+
+    # Should not raise.
+    result = await proc._signal_and_wait(signal.SIGTERM)
+
+    assert result is None
+    assert proc._killed is True
+    assert proc.running is False
+    # Let the cancellation propagate to the restart watcher.
+    try:
+        await proc._restart_process_future
+    except asyncio.CancelledError:
+        pass
+    assert proc._restart_process_future.done()


### PR DESCRIPTION
Downstream users of `simpervisor.process.SupervisedProcess` (notably `jupyter-server-proxy`) see a hard 500 error and a `ProcessLookupError` traceback when a long-running supervised child has exited on its own (e.g. on idle timeout) and the next request triggers a re-spawn.

Instead of cleanly resetting the cached process and respawning, the exception bubbles up to the proxy and is surfaced to the user as a 500.

---

This PR catches the ProcessLookupError, and handles in `_signal_and_wait`, and handles the exception as if kill was successful.